### PR TITLE
Add custom function to interact better with packager

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Default value: `grunt.util.linefeed`
 
 The delimeter to join all the source files together.
 
+#### options.customFunction
+Type: `Function`
+Arguments:
+
+* (*options*, Object) The Grunt task options object.
+* (*buffer*, Array) The array with the buffered definitions for each source file.
+
+This *function* should return the `buffer` *array* which will be used from there on in the packager. 
+
 #### options.name
 Type: `String` or `Object`
 

--- a/tasks/packager.js
+++ b/tasks/packager.js
@@ -164,6 +164,9 @@ module.exports = function(grunt) {
 			// load each component into the buffer list
 			(only ? toArray(only) : set).forEach(loadComponent);
 
+			// use a custom function to handle the buffered files
+			if (options.customFunction)  buffer = options.customFunction.call(this, options, buffer);
+
 			// convert the buffer into the actual source
 			buffer = buffer.map(function(def){ return def.source; }).join(options.separator);
 


### PR DESCRIPTION
This will make possible for example to remove undesired dependencies. For example, to only use the `options.only` files, and not their Core or More dependencies, we could use in the Gruntfile for Behavior-UI:

```
options: {
    only: [
        'Behavior-UI/*',
        'Behavior/*'
    ],
    customFunction: function(options, buffer){
        var toKeep = options.only; // assuming its Array 
        buffer = buffer.filter(function(def){
            var shouldKeep = toKeep.filter(function(only){
                var match = only.match(/([^\*]+)/);
                return match && def.key.indexOf(match[1]) == 0;
            });
            return shouldKeep.length;
        });
        return buffer;
    }
}
```

We could optionally add this as a `option` built in into the packager, but this felt more flexible.

**Note:** I'm sending this PR to your repo since [its the one that Behavior-UI is using](https://github.com/Behavior-UI/behavior-ui/blob/master/package.json#L33).
